### PR TITLE
removing redfish collection capabilities parameter when odata type is empty

### DIFF
--- a/svc-telemetry/telemetry/telemetry.go
+++ b/svc-telemetry/telemetry/telemetry.go
@@ -120,6 +120,17 @@ func (e *ExternalInterface) GetMetricDefinitionCollection(ctx context.Context,re
 	}
 	var resource map[string]interface{}
 	json.Unmarshal([]byte(data), &resource)
+	value, ok := resource["@Redfish.CollectionCapabilities"]
+	if ok{
+        oData := value.(map[string]interface{})
+		oDataType, oDataTypeFound := oData["@odata.type"]
+		if oDataTypeFound {
+		  oData := oDataType.(string)
+		  if len(oData) == 0 {
+		     delete(resource, "@Redfish.CollectionCapabilities")
+		  }
+	    }
+	}
 	resp.Body = resource
 	resp.StatusCode = http.StatusOK
 	resp.StatusMessage = response.Success
@@ -150,6 +161,17 @@ func (e *ExternalInterface) GetMetricReportDefinitionCollection(ctx context.Cont
 	}
 	var resource map[string]interface{}
 	json.Unmarshal([]byte(data), &resource)
+	value, ok := resource["@Redfish.CollectionCapabilities"]
+	if ok{
+        oData := value.(map[string]interface{})
+		oDataType, oDataTypeFound := oData["@odata.type"]
+		if oDataTypeFound {
+		  oData := oDataType.(string)
+		  if len(oData) == 0 {
+		     delete(resource, "@Redfish.CollectionCapabilities")
+		  }
+	    }
+	}
 	resp.Body = resource
 	resp.StatusCode = http.StatusOK
 	resp.StatusMessage = response.Success
@@ -235,6 +257,7 @@ func (e *ExternalInterface) GetMetricReportDefinition(ctx context.Context, req *
 	resp.Body = resource
 	resp.StatusCode = http.StatusOK
 	resp.StatusMessage = response.Success
+	
 	respBody := fmt.Sprintf("%v", resp.Body)
 	l.LogWithFields(ctx).Debugf("final response for get metric report definition: %s", string(respBody))
 	return resp


### PR DESCRIPTION
removing redfish collection capabilities parameter when odata type is empty